### PR TITLE
add license metadata to gemspec

### DIFF
--- a/climate_control.gemspec
+++ b/climate_control.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Modify your ENV}
   gem.summary       = %q{Modify your ENV easily with ClimateControl}
   gem.homepage      = 'https://github.com/thoughtbot/climate_control'
+  gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
This pull request adds the appropriate metadata to climate_control's gemspec. This allows Rubygems.org and other tools (such as gem2rpm) to automatically parse the license of the gem.
