### PR TITLE
tests: make SimpleCov optional

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
-require "simplecov"
-SimpleCov.start
+begin
+  require 'simplecov'
+  SimpleCov.start
+rescue LoadError
+  warn "warning: simplecov gem not found; skipping coverage"
+end
 
 $LOAD_PATH << File.join(File.dirname(__FILE__), "..", "lib")
 $LOAD_PATH << File.join(File.dirname(__FILE__))


### PR DESCRIPTION
If we do not have SimpleCov installed, we should be able to continue with the rest of the test suite.

Skip loading SimpleCov if it is not present. This allows the tests to run outside of Bundler if SimpleCov is not installed.