### PR TITLE
Handle TypeErrors during ENV assignment

### DIFF
--- a/lib/climate_control.rb
+++ b/lib/climate_control.rb
@@ -1,4 +1,5 @@
 require "climate_control/environment"
+require "climate_control/errors"
 require "climate_control/modifier"
 require "climate_control/version"
 

--- a/lib/climate_control/errors.rb
+++ b/lib/climate_control/errors.rb
@@ -1,0 +1,3 @@
+module ClimateControl
+  class UnassignableValueError < ArgumentError; end
+end

--- a/lib/climate_control/modifier.rb
+++ b/lib/climate_control/modifier.rb
@@ -35,7 +35,12 @@ module ClimateControl
 
     def copy_overrides_to_environment
       @environment_overrides.each do |key, value|
-        @env[key] = value
+        begin
+          @env[key] = value
+        rescue TypeError => e
+          raise UnassignableValueError,
+            "attempted to assign #{value} to #{key} but failed (#{e.message})"
+        end
       end
     end
 
@@ -67,7 +72,7 @@ module ClimateControl
 
     class OverlappingKeysWithChangedValues
       def initialize(hash_1, hash_2)
-        @hash_1 = hash_1
+        @hash_1 = hash_1 || {}
         @hash_2 = hash_2
       end
 

--- a/spec/acceptance/climate_control_spec.rb
+++ b/spec/acceptance/climate_control_spec.rb
@@ -111,6 +111,17 @@ describe "Climate control" do
     expect(ENV["BAZ"]).to be_nil
   end
 
+  it "raises when the value cannot be assigned properly" do
+    expect do
+      with_modified_env(FOO: 123)
+    end.to raise_error ClimateControl::UnassignableValueError, "attempted to assign 123 to FOO but failed (no implicit conversion of Fixnum into String)"
+
+    expect do
+      Thing = Class.new
+      with_modified_env(FOO: Thing.new)
+    end.to raise_error ClimateControl::UnassignableValueError, /attempted to assign .*Thing.* to FOO but failed \(no implicit conversion of.*\)$/
+  end
+
   def with_modified_env(options, &block)
     ClimateControl.modify(options, &block)
   end


### PR DESCRIPTION
This introduces a new error, ClimateControl::UnassignableValueError,
which is raised when attempting to assign a key/value to ENV which can't
be handled.

Closes #5
