### PR TITLE
Fix thread-unsafe lazy initialization

### DIFF
--- a/lib/climate_control.rb
+++ b/lib/climate_control.rb
@@ -4,11 +4,13 @@ require "climate_control/modifier"
 require "climate_control/version"
 
 module ClimateControl
+  @@env = ClimateControl::Environment.new
+
   def self.modify(environment_overrides, &block)
     Modifier.new(env, environment_overrides, &block).process
   end
 
   def self.env
-    @env ||= ClimateControl::Environment.new
+    @@env
   end
 end


### PR DESCRIPTION
The lazy initialization of `env` was not thread-safe. See https://github.com/thoughtbot/climate_control/pull/11#issuecomment-64269753.

Note that this gem is still not thread-safe when there is a chance that `ENV` will be accessed by other threads in an application. See #11.
