### PR TITLE
Create RSpec metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,44 +29,29 @@ ClimateControl.modify CONFIRMATION_INSTRUCTIONS_BCC: 'confirmation_bcc@example.c
 end
 ```
 
-To use with RSpec, you could define this in your spec:
+## RSpec metadata
+
+ClimateControl provides easy integration with RSpec using metadata. To set this
+up, call `ClimateControl.configure_rspec_metadata!`, you can add this to your `spec_helper.rb`.
+
+Once you've done that, you can have an example group or example use
+ClimateControl by passing `:climate_control` as an additional argument after the description
+string as key of a hash of configuration like.
 
 ```ruby
-def with_modified_env(options, &block)
-  ClimateControl.modify(options, &block)
+it 'have the correct current_email', climate_control: { CONFIRMATION_INSTRUCTIONS_BCC: 'confirmation_bcc@example.com' } do
+  sign_up_as 'john@example.com'
+  confirm_account_for_email 'john@example.com'
+  current_email.should bcc_to('confirmation_bcc@example.com')
 end
 ```
 
-This would allow for more straightforward way to modify the environment:
+To modify the environment for an entire set of tests in RSpec, you can use this on a `describe`:
 
 ```ruby
-require 'spec_helper'
-
-describe Thing, 'name' do
-  it 'appends ADDITIONAL_NAME' do
-    with_modified_env ADDITIONAL_NAME: 'bar' do
-      expect(Thing.new.name).to eq('John Doe Bar')
-    end
-  end
-
-  def with_modified_env(options, &block)
-    ClimateControl.modify(options, &block)
-  end
-end
-```
-
-To modify the environment for an entire set of tests in RSpec, use an `around`
-block:
-
-```ruby
-describe Thing, 'name' do
+describe Thing, 'name', climate_control: { CONFIRMATION_INSTRUCTIONS_BCC: 'confirmation_bcc@example.com' } do
   # ... tests
 
-  around do |example|
-    ClimateControl.modify FOO: 'bar' do
-      example.run
-    end
-  end
 end
 ```
 

--- a/lib/climate_control.rb
+++ b/lib/climate_control.rb
@@ -1,6 +1,7 @@
 require "climate_control/environment"
 require "climate_control/errors"
 require "climate_control/modifier"
+require "climate_control/rspec"
 require "climate_control/version"
 
 module ClimateControl
@@ -8,6 +9,13 @@ module ClimateControl
 
   def self.modify(environment_overrides, &block)
     Modifier.new(env, environment_overrides, &block).process
+  end
+
+  def self.configure_rspec_metadata!
+    unless @rspec_metadata_configured
+      ClimateControl::RSpec::Metadata.configure!
+      @rspec_metadata_configured = true
+    end
   end
 
   def self.env

--- a/lib/climate_control/rspec.rb
+++ b/lib/climate_control/rspec.rb
@@ -1,0 +1,53 @@
+module ClimateControl
+  module RSpec
+    class Metadata
+
+      def self.configure!
+        ::RSpec.configure do |config|
+          when_tagged_with_climate_control = { :climate_control => lambda { |v| !!v } }
+          config.around(when_tagged_with_climate_control) do |example|
+            options = example.metadata[:climate_control]
+           ClimateControlCaller.new(options, example).call
+          end
+        end
+      end
+
+      class ClimateControlCaller
+
+        def initialize(options, example)
+          @options, @example  = options, example
+        end
+
+        def call
+          handle_errors
+          ClimateControl.modify(options) do
+            example.run
+          end
+        end
+
+        private
+
+          attr_reader :options, :example
+
+          def error_message
+            message = 'please provide a hash with your environment variable. '
+            message << 'E.g climate_control: { VARIABLE_1: "bar", VARIABLE_2: "qux" }'
+          end
+
+          def handle_errors
+            if option_is_invalid? || options_is_empty?
+              raise ArgumentError, error_message
+            end
+          end
+
+          def option_is_invalid?
+            !options.respond_to?(:[])
+          end
+
+          def options_is_empty?
+            options.respond_to?(:[]) && options.empty?
+          end
+      end
+    end
+  end
+end

--- a/spec/acceptance/rspec_spec.rb
+++ b/spec/acceptance/rspec_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+ClimateControl.configure_rspec_metadata!
+
+describe "Climate control RSpec metadata" do
+
+  it "modifies the environment when tagged", climate_control: { VARIABLE_1: "bar", VARIABLE_2: "qux" } do
+    expect(ENV["VARIABLE_1"]).to eq "bar"
+    expect(ENV["VARIABLE_2"]).to eq "qux"
+  end
+
+  it "does not modifies the environment when not tagged" do
+    expect(ENV["VARIABLE_1"]).to eq nil
+    expect(ENV["VARIABLE_2"]).to eq nil
+  end
+
+  describe "works at group level", climate_control: { VARIABLE_1: "bar", VARIABLE_2: "qux" } do
+
+
+    it "defines the variable for one example" do
+      expect(ENV["VARIABLE_1"]).to eq "bar"
+    end
+
+    it "defines the variable for other example" do
+      expect(ENV["VARIABLE_2"]).to eq "qux"
+    end
+  end
+
+  describe ClimateControl::RSpec::Metadata::ClimateControlCaller do
+
+    describe '#call' do
+
+      subject do
+        ClimateControl::RSpec::Metadata::ClimateControlCaller.new(options, example)
+      end
+
+      let(:example) do
+        double(:example, run: true)
+      end
+
+      let(:message) do
+        message = 'please provide a hash with your environment variable. '
+        message << 'E.g climate_control: { VARIABLE_1: "bar", VARIABLE_2: "qux" }'
+      end
+
+      describe 'handle of errors' do
+
+        context 'with boolean' do
+
+          let(:options) do
+            true
+          end
+
+          it 'raises correct error' do
+            expect do
+              subject.call
+            end.to raise_error(ArgumentError, message)
+          end
+        end
+
+        context 'with nil' do
+
+          let(:options) do
+            nil
+          end
+
+          it 'raises correct error' do
+            expect do
+              subject.call
+            end.to raise_error(ArgumentError, message)
+          end
+        end
+
+        context 'with empty hash' do
+
+          let(:options) do
+            {}
+          end
+
+          it 'raises correct error' do
+            expect do
+              subject.call
+            end.to raise_error(ArgumentError, message)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The [VCR](https://relishapp.com/vcr/vcr/v/2-8-0/docs) uses a API that is possible move the block syntax to a [RSpec metadata](https://relishapp.com/vcr/vcr/v/2-8-0/docs/test-frameworks/usage-with-rspec-metadata).

This

``` ruby
it 'my spec' do
  VCR.use_cassette('synopsis') do
    # code here
  end
end
```

became

``` ruby
it 'my spec', vcr: { cassette_name: 'synopsis' } do
  # code here
end
```

I added the same behavior on Climate Control. So this

``` ruby
ClimateControl.modify CONFIRMATION_INSTRUCTIONS_BCC: 'confirmation_bcc@example.com' do
  sign_up_as 'john@example.com'
  confirm_account_for_email 'john@example.com'
  current_email.should bcc_to('confirmation_bcc@example.com')
end
```

became

``` ruby
it 'have the correct current_email', climate_control: { CONFIRMATION_INSTRUCTIONS_BCC: 'confirmation_bcc@example.com' } do
  sign_up_as 'john@example.com'
  confirm_account_for_email 'john@example.com'
  current_email.should bcc_to('confirmation_bcc@example.com')
end
```

Do you guys think that makes sense?
