### PR TITLE
Added support for auto-converting booleans and numbers as strings.

### DIFF
--- a/lib/climate_control/modifier.rb
+++ b/lib/climate_control/modifier.rb
@@ -33,10 +33,24 @@ module ClimateControl
       @block.call
     end
 
+    def stringify_boolean(value)
+      return value.to_s if [true, false].include?(value)
+      value
+    end
+
+    def stringify_number(value)
+      return value.to_s if value.is_a?(Numeric)
+      value
+    end
+
+    def stringify_value(value)
+      stringify_number(stringify_boolean(value))
+    end
+
     def copy_overrides_to_environment
       @environment_overrides.each do |key, value|
         begin
-          @env[key] = value
+          @env[key] = stringify_value(value)
         rescue TypeError => e
           raise UnassignableValueError,
             "attempted to assign #{value} to #{key} but failed (#{e.message})"

--- a/spec/acceptance/climate_control_spec.rb
+++ b/spec/acceptance/climate_control_spec.rb
@@ -22,6 +22,13 @@ describe "Climate control" do
     expect(ENV["VARIABLE_2"]).to be_nil
   end
 
+  it "converts booleans and numbers to strings" do
+    with_modified_env VARIABLE_1: true, VARIABLE_2: 1 do
+      expect(ENV["VARIABLE_1"]).to eq "true"
+      expect(ENV["VARIABLE_2"]).to eq "1"
+    end
+  end
+
   it "allows for environment variables to be assigned within the block" do
     with_modified_env VARIABLE_1: "modified" do
       ENV["ASSIGNED_IN_BLOCK"] = "assigned"


### PR DESCRIPTION
- Aids the development process by accepting and converting boolean
  and/or numeric values as strings for safe storage within the ENV.
- Without this conversion support, the following exception is thrown:
  "NoMethodError: undefined method `keys' for nil:NilClass". This
  makes for a confusing debugging process as it is not intuitive
  that the error stems from the Climate Control gem.
- Alternative solutions for consideration:
    - Convert ALL values to strings (i.e. String(value)). This
      would mean the "raises when the value cannot be assigned properly"
      spec might not be necessary.
    - Don't do any conversion and raise exceptions instead.
    - Allow for conversion but print warnings that code should be
      cleaned up to not use booleans or numerics.