### PR TITLE
Remove activesupport dependency

### DIFF
--- a/climate_control.gemspec
+++ b/climate_control.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activesupport", ">= 3.0"
   gem.add_development_dependency "rspec", "~> 3.1.0"
   gem.add_development_dependency "rake", "~> 10.3.2"
   gem.add_development_dependency "simplecov", "~> 0.9.1"

--- a/lib/climate_control/environment.rb
+++ b/lib/climate_control/environment.rb
@@ -1,18 +1,18 @@
 require "thread"
-require "active_support/core_ext/module/delegation"
+require "forwardable"
 
 module ClimateControl
   class Environment
+    extend Forwardable
+
     def initialize
       @semaphore = Mutex.new
     end
 
-    delegate :[]=, :to_hash, :[], :delete, to: :env
-    delegate :synchronize, to: :semaphore
+    def_delegators :env, :[]=, :to_hash, :[], :delete
+    def_delegator :@semaphore, :synchronize
 
     private
-
-    attr_reader :semaphore
 
     def env
       ENV

--- a/lib/climate_control/modifier.rb
+++ b/lib/climate_control/modifier.rb
@@ -1,9 +1,7 @@
-require "active_support/core_ext/hash/keys"
-
 module ClimateControl
   class Modifier
     def initialize(env, environment_overrides = {}, &block)
-      @environment_overrides = environment_overrides.dup.stringify_keys!
+      @environment_overrides = stringify_keys(environment_overrides)
       @block = block
       @env = env
     end
@@ -68,6 +66,12 @@ module ClimateControl
 
     def clone_environment
       @env.to_hash
+    end
+
+    def stringify_keys(env)
+      env.each_with_object({}) do |(key, value), hash|
+        hash[key.to_s] = value
+      end
     end
 
     class OverlappingKeysWithChangedValues


### PR DESCRIPTION
`activesupport` is a really heavy dependency and rather unnecessary as well. Only two features were used and both were pretty simple to replace.

For delegation the standard library provides the `Forwardable` module which has the same functionality with a slightly different syntax.

For `Hash#stringify_keys` I added a simple implementation when `activesupport` cannot be loaded. Otherwise just use `activesupport`'s implementation.

I also added the most recent versions of ruby to the Travis test matrix. Ruby supposed to follow semantic versioning in the 2.x.x series but better be safe than sorry.

@joshuaclayton if you merge this can you please create a new release? The current (0.0.3) is rather old and a lot of things have happened since then. Thanks.
