### PR TITLE
Clean up a test warning

### DIFF
--- a/spec/acceptance/climate_control_spec.rb
+++ b/spec/acceptance/climate_control_spec.rb
@@ -54,7 +54,7 @@ describe "Climate control" do
       with_modified_env FOO: "bar" do
         raise "broken"
       end
-    }.to raise_error
+    }.to raise_error("broken")
 
     expect(ENV["FOO"]).to be_nil
   end


### PR DESCRIPTION
The warning was cluttering test output:

```
WARNING: Using the `raise_error` matcher without providing a specific
error or message risks false positives, since `raise_error` will match
when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`,
potentially allowing the expectation to pass without even executing the
method you are intending to call. Actual error raised was
\#<RuntimeError: broken>. Instead consider providing a specific error
class or message. This message can be supressed by setting:
`RSpec::Expectations.configuration.warn_about_potential_false_positives
= false`.
```