### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.5
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
 before_install:
   - gem update --system
+  - gem update bundler
 install: "bundle install"
 branches:
   only:


### PR DESCRIPTION
This:

* Removes testing against 1.9.3
* Adds testing for the newest 2.x releases
* Ensures Bundler has been updated before installing gems