### PR TITLE
Make ClimateControl.modify re-entrant

### DIFF
--- a/lib/climate_control/environment.rb
+++ b/lib/climate_control/environment.rb
@@ -7,10 +7,25 @@ module ClimateControl
 
     def initialize
       @semaphore = Mutex.new
+      @owner = nil
     end
 
     def_delegators :env, :[]=, :to_hash, :[], :delete
-    def_delegator :@semaphore, :synchronize
+
+    def synchronize
+      if @owner == Thread.current
+        return yield if block_given?
+      end
+
+      @semaphore.synchronize do
+        begin
+          @owner = Thread.current
+          yield if block_given?
+        ensure
+          @owner = nil
+        end
+      end
+    end
 
     private
 

--- a/spec/acceptance/climate_control_spec.rb
+++ b/spec/acceptance/climate_control_spec.rb
@@ -111,6 +111,19 @@ describe "Climate control" do
     expect(ENV["BAZ"]).to be_nil
   end
 
+  it "is re-entrant" do
+    ret = with_modified_env(FOO: "foo") do
+      with_modified_env(BAR: "bar") do
+        "bar"
+      end
+    end
+
+    expect(ret).to eq("bar")
+
+    expect(ENV["FOO"]).to be_nil
+    expect(ENV["BAR"]).to be_nil
+  end
+
   it "raises when the value cannot be assigned properly" do
     Thing = Class.new
     message = generate_type_error_for_object(Thing.new)


### PR DESCRIPTION
With the lock added in 0.4, it's no longer safe to nest calls
`ClimateControl.modify`, which is actually a useful feature when e.g.
using `ClimateControl` in RSpec `around { ... }` blocks. Doing so
results in a deadlock (stack trace from the spec included in this
commit):

```
1) Climate control is re-entrant
   Failure/Error: ClimateControl.modify(options, &block)
   ThreadError:
     deadlock; recursive locking
   # ./lib/climate_control/modifier.rb:10:in `process'
   # ./lib/climate_control.rb:10:in `modify'
   # ./spec/acceptance/climate_control_spec.rb:131:in `with_modified_env'
   # ./spec/acceptance/climate_control_spec.rb:116:in `block (3 levels) in <top (required)>'
   # ./lib/climate_control/modifier.rb:31:in `call'
   # ./lib/climate_control/modifier.rb:31:in `run_block'
   # ./lib/climate_control/modifier.rb:13:in `block in process'
   # ./lib/climate_control/modifier.rb:10:in `process'
   # ./lib/climate_control.rb:10:in `modify'
   # ./spec/acceptance/climate_control_spec.rb:131:in `with_modified_env'
   # ./spec/acceptance/climate_control_spec.rb:115:in `block (2 levels) in <top (required)>'
   # ./spec/acceptance/climate_control_spec.rb:149:in `block (2 levels) in <top (required)>'
```

Since the lock is here to protect against different threads accessing
ClimateControl at the same time, it's safe for a given thread to make
any changes it wants to the environment as long as it holds the locks,
which is what this patch does.

---

There was a bit of discussion about re-entrancy in #11, but I don't think the fact that `ClimateControl` will deadlock when nesting calls in the absence of re-entrancy was addressed.

Thanks!