### PR TITLE
CI: Workaround YAML gotcha in Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.0, 2.7, 2.6, 2.5]
+        ruby-version: ['3.0', 2.7, 2.6, 2.5]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}


### PR DESCRIPTION
To avoid unexpectedly stop testing Ruby 3.0 when Ruby 3.1 is released.

See https://github.com/actions/runner/issues/849

At https://github.com/thoughtbot/climate_control/runs/2049131377?check_suite_focus=true#step:3:3 we can see that the setup-ruby action ran with just `3` as the input and not `3.0`.