### PR TITLE
Add requirement on Ruby version 2.5+

### DIFF
--- a/climate_control.gemspec
+++ b/climate_control.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.required_ruby_version = ">= 2.5.0"
+
   gem.add_development_dependency "rspec", "~> 3.10.0"
   gem.add_development_dependency "rake", "~> 12.3.3"
   gem.add_development_dependency "simplecov", "~> 0.9.1"


### PR DESCRIPTION
A recent commit using StandardRB to reformat sources dropped the `begin` in `rescue` and `ensure` blocks, but using those keywords in blocks without a `begin` is only available in Ruby 2.5.0 or later.

https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/

Add a requirement on version of Ruby to be >= 2.5.0 to the gemspec.

Bump up version to 1.0.1 to allow releasing a new gem including this requirement. **SUGGESTION:** After merging this PR, please release version 1.0.1 to Rubygems and remove version 1.0.0, so that using gem/bundler on older versions of Ruby will successfully figure out which was the last version of this gem that worked on that version of Ruby.

Tested:

```
$ ruby -v
ruby 2.4.9p362 (2019-10-02 revision 67824) [x86_64-linux]
$ gem install ./climate_control-1.0.1.gem
ERROR:  Error installing ./climate_control-1.0.1.gem:
        climate_control requires Ruby version >= 2.5.0.
```

Failure while running rake/rspec on Ruby 2.4:

```
An error occurred while loading ./spec/acceptance/climate_control_spec.rb.
Failure/Error: require "climate_control/environment"

SyntaxError:
  ./lib/climate_control/environment.rb:22: syntax error, unexpected keyword_ensure, expecting keyword_end
	ensure
	      ^
  ./lib/climate_control/environment.rb:33: syntax error, unexpected keyword_end, expecting end-of-input
# ./lib/climate_control.rb:1:in `<top (required)>'
# ./spec/spec_helper.rb:13:in `<top (required)>'
# ./spec/acceptance/climate_control_spec.rb:1:in `<top (required)>'
No examples found.
```
