### PR TITLE
Allow ClimateControl.modify to be called without environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ end
 To use with RSpec, you could define this in your spec:
 
 ```ruby
-def with_modified_env(options, &block)
+def with_modified_env(options = {}, &block)
   ClimateControl.modify(options, &block)
 end
 ```

--- a/lib/climate_control.rb
+++ b/lib/climate_control.rb
@@ -6,7 +6,7 @@ require "climate_control/version"
 module ClimateControl
   @@env = ClimateControl::Environment.new
 
-  def self.modify(environment_overrides, &block)
+  def self.modify(environment_overrides = {}, &block)
     Modifier.new(env, environment_overrides, &block).process
   end
 


### PR DESCRIPTION
### Why was this change necessary?

When wanting to wrap some block inside ClimateControl for thread safety
for instance it's useful to be able to just call:

`ClimateControl.modify { }` or `with_modified_env {}`

See #38 for an example.

### How does it address the problem?

This changes allows `.modify` to be called without an environment
variables hash (defaults to empty hash `{}`).

### Are there any side effects?

Some applications could theoretically be relying on the fact that
calling .modify without an environment variables hash would raise an
error. I think it's very unlikely.