### PR TITLE
Add test for nested usage

### DIFF
--- a/spec/acceptance/climate_control_spec.rb
+++ b/spec/acceptance/climate_control_spec.rb
@@ -185,10 +185,10 @@ describe "Climate control" do
   it "doesn't block on nested modify calls" do
     with_modified_env(SMS_DEFAULT_COUNTRY_CODE: nil) do
       with_modified_env(SMS_DEFAULT_COUNTRY_CODE: "++56") do
-        expect(ENV["SMS_DEFAULT_COUNTRY_CODE"]).to eq("++56")
+        expect(ENV.fetch("SMS_DEFAULT_COUNTRY_CODE", "++41")).to eq("++56")
       end
 
-      expect(ENV["SMS_DEFAULT_COUNTRY_CODE"]).to eq(nil)
+      expect(ENV.fetch("SMS_DEFAULT_COUNTRY_CODE", "++41")).to eq("++41")
     end
   end
 

--- a/spec/acceptance/climate_control_spec.rb
+++ b/spec/acceptance/climate_control_spec.rb
@@ -182,6 +182,16 @@ describe "Climate control" do
     expect(ENV["KEY_THAT_WILL_ERROR_OUT"]).to eq("initial_value_2")
   end
 
+  it "doesn't block on nested modify calls" do
+    with_modified_env(SMS_DEFAULT_COUNTRY_CODE: nil) do
+      with_modified_env(SMS_DEFAULT_COUNTRY_CODE: "++56") do
+        expect(ENV["SMS_DEFAULT_COUNTRY_CODE"]).to eq("++56")
+      end
+
+      expect(ENV["SMS_DEFAULT_COUNTRY_CODE"]).to eq(nil)
+    end
+  end
+
   def with_modified_env(options = {}, &block)
     ClimateControl.modify(options, &block)
   end


### PR DESCRIPTION
### Why was this change necessary?

From #46 there could be a deadlock from nested usage

### How does it address the problem?

This commit adds a test for nested usage and it passes with no library
change.

Fixes #46