### PR TITLE
Added: `ClimateControl.unsafe_modify` (thread-unsafe `modify`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.2.0 / 2022-07-15
+
+- Added: `ClimateControl.unsafe_modify` for a thread-unsafe version of
+  `ClimateControl.modify` (useful for minitest-around for instance)
 
 ## 1.1.1 / 2022-05-28
 

--- a/lib/climate_control.rb
+++ b/lib/climate_control.rb
@@ -31,6 +31,27 @@ module ClimateControl
     end
   end
 
+  def unsafe_modify(environment_overrides = {}, &block)
+    environment_overrides = environment_overrides.transform_keys(&:to_s)
+
+    previous = ENV.to_hash
+
+    begin
+      copy environment_overrides
+    ensure
+      middle = ENV.to_hash
+    end
+
+    block.call
+  ensure
+    after = ENV
+    (previous.keys | middle.keys | after.keys).each do |key|
+      if previous[key] != after[key] && middle[key] == after[key]
+        ENV[key] = previous[key]
+      end
+    end
+  end
+
   def env
     ENV
   end

--- a/lib/climate_control/version.rb
+++ b/lib/climate_control/version.rb
@@ -1,3 +1,3 @@
 module ClimateControl
-  VERSION = "1.1.1".freeze
+  VERSION = "1.2.0".freeze
 end

--- a/spec/acceptance/unsafe_modify_spec.rb
+++ b/spec/acceptance/unsafe_modify_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
-Thing = Class.new
-
-describe "Climate control" do
+describe "ClimateControl#unsafe_modify" do
   it "allows modification of the environment" do
     block_run = false
     with_modified_env FOO: "bar" do
@@ -113,39 +111,6 @@ describe "Climate control" do
     expect(ENV["BAZ"]).to be_nil
   end
 
-  it "handles threads accessing the same key wrapped in a block" do
-    first_thread = Thread.new {
-      with_modified_env do
-        with_modified_env CONFLICTING_KEY: "1" do
-          sleep 0.5
-          expect(ENV["CONFLICTING_KEY"]).to eq("1")
-        end
-
-        expect(ENV["CONFLICTING_KEY"]).to be_nil
-      end
-    }
-
-    second_thread = Thread.new {
-      with_modified_env do
-        sleep 0.25
-        expect(ENV["CONFLICTING_KEY"]).to be_nil
-
-        with_modified_env CONFLICTING_KEY: "2" do
-          expect(ENV["CONFLICTING_KEY"]).to eq("2")
-          sleep 0.5
-          expect(ENV["CONFLICTING_KEY"]).to eq("2")
-        end
-
-        expect(ENV["CONFLICTING_KEY"]).to be_nil
-      end
-    }
-
-    first_thread.join
-    second_thread.join
-
-    expect(ENV["CONFLICTING_KEY"]).to be_nil
-  end
-
   it "is re-entrant" do
     ret = with_modified_env(FOO: "foo") {
       with_modified_env(BAR: "bar") do
@@ -193,7 +158,7 @@ describe "Climate control" do
   end
 
   def with_modified_env(options = {}, &block)
-    ClimateControl.modify(options, &block)
+    ClimateControl.unsafe_modify(options, &block)
   end
 
   def generate_type_error_for_object(object)


### PR DESCRIPTION
### Why was this change necessary?

When using Fiber (like minitest-around does), we can't share a semaphore
between Fibers (change from Ruby on purpose)

### How does it address the problem?

`unsafe_modify` is the same as `modify` except that it doesn't get a
lock on `ENV`

### Are there any side effects?

`unsafe_modify` doesn't use the semaphore thus will not guarantee
consistency of ENV if used with threads.