### PR TITLE
Drop EOL ruby versions from spec and support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.1, '3.0', 2.7, 2.6, 2.5]
+        ruby-version: [3.2, 3.1, '3.0', 2.7]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/climate_control.gemspec
+++ b/climate_control.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.5.0"
+  gem.required_ruby_version = ">= 2.7.0"
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Why this change is being made:
- Updating to use the latest ruby and drop support for unsupported ruby versions

What were the changes made to support this:
- Update the test matrix to drop 2.5 and 2.6 rubies and add 3.2