### PR TITLE
Update CI actions to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,12 @@ jobs:
       matrix:
         ruby-version: [3.2, 3.1, '3.0', 2.7]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
       - name: Install gems
         run: |
           bundle config path vendor/bundle


### PR DESCRIPTION
This change does two things, updates the actions/checkout to v3 which is latest and adds a bundler-cache to the matrix for ruby versions. We rarely update the gemspec with new dependencies so I don't think a cache will hurt us. 