### PR TITLE
ci: Remove redundant Bundle Install call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
       - name: Run tests
         run: bundle exec rake
       - name: Run StandardRB


### PR DESCRIPTION
The install is already done by the `bundler-cache: true` setting in the setup-ruby action https://github.com/ruby/setup-ruby#caching-bundle-install-automatically