### PR TITLE
Add CHANGELOG URI to gemspec

### DIFF
--- a/climate_control.gemspec
+++ b/climate_control.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.summary = "Modify your ENV easily with ClimateControl"
   gem.homepage = "https://github.com/thoughtbot/climate_control"
   gem.license = "MIT"
+  gem.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
   gem.files = `git ls-files`.split($/)
   gem.require_paths = ["lib"]


### PR DESCRIPTION
This allows rubygems.org to add a link to the changelog directly from the gem page.