### PR TITLE
Revert "remove deprecated env method, bump version to 1.3.0"

### DIFF
--- a/lib/climate_control.rb
+++ b/lib/climate_control.rb
@@ -41,6 +41,14 @@ module ClimateControl
     merge(ENV, previous: previous, middle: middle, after: after)
   end
 
+  deprecate :unsafe_modify, :modify, 2024, 11
+
+  def env
+    ENV
+  end
+
+  deprecate :env, "ENV", 2022, 10
+
   private
 
   def copy(overrides)

--- a/lib/climate_control/version.rb
+++ b/lib/climate_control/version.rb
@@ -1,3 +1,3 @@
 module ClimateControl
-  VERSION = "1.3.0".freeze
+  VERSION = "1.2.0".freeze
 end


### PR DESCRIPTION
Reverts thoughtbot/climate_control#65

We shouldn't change versions outside the release commit — this makes it easier to see when the release was cut, especially as it'll include CHANGELOG entries too.

I'd also generally wait until releasing a major version. We don't know who's relying on a deprecated method, and seeing a major version coming in and then you're tests failing all of a sudden is a better hint.