### PR TITLE
CI against Ruby 3.3 and 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.2, 3.1, '3.0', 2.7]
+        ruby-version: [3.4, 3.3, 3.2, 3.1, '3.0', 2.7]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}


### PR DESCRIPTION
Ruby 3.3 and 3.4 have been available right now.