### PR TITLE
Add tests and documentation for temporarily unsetting environment variables with nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ ClimateControl.modify CONFIRMATION_INSTRUCTIONS_BCC: 'confirmation_bcc@example.c
 end
 ```
 
+To temporarily unset an environment variable, pass `nil` as the value:
+
+```ruby
+ClimateControl.modify API_KEY: nil do
+  # ENV["API_KEY"] will be nil within this block
+  # It will be restored to its original value (or remain unset if it was never set)
+  # after the block ends
+end
+```
+
 To use with RSpec, you could define this in your spec:
 
 ```ruby

--- a/spec/acceptance/climate_control_spec.rb
+++ b/spec/acceptance/climate_control_spec.rb
@@ -192,6 +192,18 @@ describe "Climate control" do
     end
   end
 
+  it "temporarily unsets environment variables when passing nil as value" do
+    ENV["TEMP_VAR"] = "some_value"
+    expect(ENV["TEMP_VAR"]).to eq("some_value")
+
+    with_modified_env(TEMP_VAR: nil) do
+      expect(ENV["TEMP_VAR"]).to be_nil
+      expect(ENV.key?("TEMP_VAR")).to be false
+    end
+
+    expect(ENV["TEMP_VAR"]).to eq("some_value")
+  end
+
   def with_modified_env(options = {}, &block)
     ClimateControl.modify(options, &block)
   end

--- a/spec/acceptance/unsafe_modify_spec.rb
+++ b/spec/acceptance/unsafe_modify_spec.rb
@@ -157,6 +157,18 @@ describe "ClimateControl#unsafe_modify" do
     end
   end
 
+  it "temporarily unsets environment variables when passing nil as value" do
+    ENV["TEMP_VAR"] = "some_value"
+    expect(ENV["TEMP_VAR"]).to eq("some_value")
+
+    with_modified_env(TEMP_VAR: nil) do
+      expect(ENV["TEMP_VAR"]).to be_nil
+      expect(ENV.key?("TEMP_VAR")).to be false
+    end
+
+    expect(ENV["TEMP_VAR"]).to eq("some_value")
+  end
+
   def with_modified_env(options = {}, &block)
     ClimateControl.unsafe_modify(options, &block)
   end


### PR DESCRIPTION
`ClimateControl.modify` and `ClimateControl.unsafe_modify` have the ability to temporarily unset environment variables when `nil` is passed as a value, but this functionality was not explicitly tested or documented. Without clear documentation, developers might not realize this option exists.

This change includes:
1. Adds test cases for both `ClimateControl.modify` and `ClimateControl.unsafe_modify` to verify that passing nil as a value temporarily unsets environment variables
2. Updates the README.md to document how to temporarily unset environment variables

By making this feature explicit in tests and documentation, it clarifies that this gem supports a wider range of use cases, allowing users to confidently use this functionality in their applications.